### PR TITLE
Add support for enums with generics

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 extern crate enum_default;
 use enum_default::EnumDefault;
 
@@ -14,7 +16,22 @@ enum TestEnum2 {
     Second = 1337,
 }
 
+#[derive(EnumDefault, PartialEq)]
+enum TestEnum3<T> {
+    A,
+    B(T),
+}
+
+#[derive(EnumDefault, PartialEq)]
+enum TestEnum4<T> {
+    A(T),
+    #[default]
+    B,
+}
+
 fn main() {
     assert!(TestEnum::default() == TestEnum::First);
     assert!(TestEnum2::default() == TestEnum2::Second);
+    assert!(TestEnum3::<()>::default() == TestEnum3::A);
+    assert!(TestEnum4::<()>::default() == TestEnum4::B);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,14 @@ pub fn enum_default_derive(input: TokenStream) -> TokenStream {
                 return TokenStream::default();
             }
             let name = ast.ident;
+            let generics = ast.generics;
 
             // check if they have the "#[default]" attribute
             let iter = data.variants.iter();
             for variant in iter {
                 for attr in &variant.attrs {
                     if attr.path.is_ident("default") {
-                        return impl_enum_default(&name, &variant.ident);
+                        return impl_enum_default(&name, &generics, &variant.ident);
                     }
                 }
             }
@@ -28,17 +29,21 @@ pub fn enum_default_derive(input: TokenStream) -> TokenStream {
             // fallback to the first item
             let first_variant = data.variants.first().unwrap();
             let variant = &first_variant.ident;
-            impl_enum_default(&name, variant)
+            impl_enum_default(&name, &generics, variant)
         }
         _ => TokenStream::default(),
     }
 }
 
-fn impl_enum_default(name: &syn::Ident, variant: &syn::Ident) -> TokenStream {
+fn impl_enum_default(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    variant: &syn::Ident,
+) -> TokenStream {
     let result = quote! {
-      impl Default for #name {
-        fn default() -> #name {
-          #name::#variant
+      impl#generics Default for #name#generics {
+        fn default() -> Self {
+          Self::#variant
         }
       }
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,50 @@
+#![allow(dead_code)]
+
+extern crate enum_default;
+use enum_default::EnumDefault;
+
+#[test]
+pub fn it_derives_default_for_enum_from_first_variant() {
+    #[derive(EnumDefault, PartialEq)]
+    enum TestEnum {
+        A,
+        B,
+    }
+
+    assert!(TestEnum::default() == TestEnum::A);
+}
+
+#[test]
+pub fn it_derives_default_for_enum_from_explicit_variant() {
+    #[derive(EnumDefault, PartialEq)]
+    enum TestEnum {
+        A,
+        #[default]
+        B,
+    }
+
+    assert!(TestEnum::default() == TestEnum::B);
+}
+
+#[test]
+pub fn it_derives_default_for_enum_with_generics_from_first_variant() {
+    #[derive(EnumDefault, PartialEq)]
+    enum TestEnum<T> {
+        A,
+        B(T),
+    }
+
+    assert!(TestEnum::<()>::default() == TestEnum::A);
+}
+
+#[test]
+pub fn it_derives_default_for_enum_with_generics_from_explicit_variant() {
+    #[derive(EnumDefault, PartialEq)]
+    enum TestEnum<T> {
+        A(T),
+        #[default]
+        B,
+    }
+
+    assert!(TestEnum::<()>::default() == TestEnum::B);
+}


### PR DESCRIPTION
This PR adds support for deriving a default implementation for Enums that have generics.

I've also created tests from the example.

An example that is similar to what I'm using this for.

```rust
#[derive(EnumDefault, PartialEq)]
enum HasMany<T> {
    NotLoaded,
    LoadFailed,
    Loaded(T),
}

#[derive(Default, PartialEq)]
struct A;

#[derive(Default, PartialEq)]
struct B;

#[derive(Default, PartialEq)]
struct Model {
    pub a: A,
    pub b: HasMany<B>,
}

let model = Model::default();

assert!(model.b == HasMany::<B>::NotLoaded);
```